### PR TITLE
Add Validator Summary tab (SN120 public API)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Monitor, Moon, Sun, Code, ExternalLink, Activity } from 'lucide-react';
 import Header from './components/Header';
 import OverviewTable from './components/OverviewTable';
 import ModelGrid from './components/ModelGrid';
+import ValidatorSummary from './components/ValidatorSummary';
 import CodeViewer from './components/CodeViewer';
 import { useTheme } from './hooks/useTheme';
 import { useModelsData } from './hooks/useModelsData';
@@ -87,6 +88,25 @@ function App() {
                 ALL MODELS
               </div>
             </button>
+            <button
+              onClick={() => setActiveTab('validator')}
+              className={`px-6 py-3 font-mono text-xs uppercase tracking-wider border-r-2 transition-colors ${
+                activeTab === 'validator'
+                  ? theme === 'dark'
+                    ? 'bg-gray-800 text-white border-white'
+                    : 'bg-white text-gray-900 border-gray-300'
+                  : theme === 'dark'
+                    ? 'bg-black text-gray-300 border-white hover:bg-gray-800 hover:text-white'
+                    : 'bg-cream-100 text-gray-600 border-gray-300 hover:bg-white hover:text-gray-800'
+              }`}
+            >
+              Validator
+              <div className={`text-xs mt-1 font-mono ${
+                theme === 'dark' ? 'text-gray-400' : 'text-gray-500'
+              }`}>
+                SUMMARY GRID
+              </div>
+            </button>
             {environments.map((env) => (
               <button
                 key={env.id}
@@ -117,6 +137,8 @@ function App() {
             environments={environments}
             theme={theme}
           />
+        ) : activeTab === 'validator' ? (
+          <ValidatorSummary theme={theme} />
         ) : (
           <>
             {/* Current Environment Info */}

--- a/src/components/ValidatorSummary.tsx
+++ b/src/components/ValidatorSummary.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { useValidatorSummary } from '../hooks/useValidatorSummary';
+
+interface Props {
+  theme: 'light' | 'dark';
+}
+
+const ValidatorSummary: React.FC<Props> = ({ theme }) => {
+  const { data, loading, error, refetch } = useValidatorSummary();
+
+  if (loading) {
+    return (
+      <div className={`p-6 border-2 rounded-none text-center ${theme === 'dark' ? 'border-white bg-black' : 'border-gray-300 bg-cream-100'}`}>
+        <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-current mx-auto mb-3" />
+        <div className="font-mono text-xs uppercase tracking-wider">Loading validator summary…</div>
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className={`p-6 border-2 rounded-none text-center ${theme === 'dark' ? 'border-white bg-black' : 'border-gray-300 bg-cream-100'}`}>
+        <div className={`font-mono text-sm uppercase tracking-wider mb-2 ${theme === 'dark' ? 'text-red-400' : 'text-red-600'}`}>Error</div>
+        <div className="font-sans text-sm mb-4">{error || 'Failed to load data.'}</div>
+        <button
+          onClick={refetch}
+          className={`px-4 py-2 border-2 font-mono text-xs uppercase tracking-wider transition-colors ${
+            theme === 'dark'
+              ? 'border-white text-white hover:bg-white hover:text-black'
+              : 'border-gray-900 text-gray-900 hover:bg-gray-900 hover:text-white'
+          }`}
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  const { columns, rows, timestamp, tail } = data;
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className={`p-4 border-2 rounded-none ${theme === 'dark' ? 'border-white bg-black' : 'border-gray-300 bg-cream-100'}`}>
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className={`text-xl font-mono font-bold ${theme === 'dark' ? 'text-white' : 'text-gray-900'}`}>
+              VALIDATOR SUMMARY
+            </h2>
+            <div className={`text-xs font-mono uppercase tracking-wider mt-1 ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>
+              Tail {tail} • {new Date(timestamp).toLocaleString()}
+            </div>
+          </div>
+          <button
+            onClick={refetch}
+            className={`px-4 py-2 border-2 font-mono text-xs uppercase tracking-wider transition-colors ${
+              theme === 'dark'
+                ? 'border-white text-white hover:bg-white hover:text-black'
+                : 'border-gray-900 text-gray-900 hover:bg-gray-900 hover:text-white'
+            }`}
+          >
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {/* Grid */}
+      <div className={`overflow-auto border-2 rounded-none ${theme === 'dark' ? 'border-white' : 'border-gray-300'}`}>
+        <table className={`min-w-full ${theme === 'dark' ? 'bg-black text-white' : 'bg-white text-gray-900'}`}>
+          <thead>
+            <tr>
+              {columns.map((col) => (
+                <th
+                  key={col}
+                  className={`px-4 py-2 border-b-2 font-mono text-xs uppercase tracking-wider text-left ${
+                    theme === 'dark' ? 'border-white' : 'border-gray-300'
+                  }`}
+                >
+                  {col}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, i) => (
+              <tr key={i} className={i % 2 === 0 ? (theme === 'dark' ? 'bg-black' : 'bg-white') : (theme === 'dark' ? 'bg-black' : 'bg-cream-50')}>
+                {row.map((cell, j) => (
+                  <td
+                    key={j}
+                    className={`px-4 py-2 border-t font-sans text-sm ${
+                      theme === 'dark' ? 'border-white/20' : 'border-gray-200'
+                    }`}
+                  >
+                    {cell as any}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default ValidatorSummary;
+

--- a/src/hooks/useValidatorSummary.ts
+++ b/src/hooks/useValidatorSummary.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+
+interface SummaryResponse {
+  timestamp: string;
+  tail: number;
+  columns: string[];
+  rows: (string | number | null)[][];
+  raw?: string;
+}
+
+export const useValidatorSummary = () => {
+  const [data, setData] = useState<SummaryResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const res = await fetch('https://sn120-viewer.onrender.com/api/weights/summary/latest', { cache: 'no-store' });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const json: SummaryResponse = await res.json();
+      setData(json);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+    const id = setInterval(fetchData, 30000);
+    return () => clearInterval(id);
+  }, []);
+
+  return { data, loading, error, refetch: fetchData } as const;
+};
+


### PR DESCRIPTION
This PR adds a new Validator Summary tab and grid that pulls live data from the SN120 Viewer public endpoint.\n\nChanges\n- New hook: src/hooks/useValidatorSummary.ts (fetches https://sn120-viewer.onrender.com/api/weights/summary/latest)\n- New component: src/components/ValidatorSummary.tsx (black/cream, mono, 2px borders)\n- App integration: new "Validator" tab in src/App.tsx\n\nNotes\n- No env vars required; endpoint is public.\n- Styling is consistent with current vintage dashboard aesthetic.\n\nHappy to tweak column order or add filters/pagination in follow-ups.